### PR TITLE
Use valid default sdf file for gazebo sim

### DIFF
--- a/src/picknik_kinova_gen3_gz_config/launch/sim/hardware.launch.py
+++ b/src/picknik_kinova_gen3_gz_config/launch/sim/hardware.launch.py
@@ -55,7 +55,7 @@ def generate_simulation_description(context, *args, **settings):
         world_name_key = "gazebo_test_world_name"
     else:
         world_name_key = "gazebo_world_name"
-    world_name = settings.get(world_name_key, "studio_simple.sdf")
+    world_name = settings.get(world_name_key, "empty.sdf")
 
     use_gui = settings.get("gazebo_gui", False)
     is_verbose = settings.get("gazebo_verbose", False)


### PR DESCRIPTION
Before, the kinova sim config package attempted to use the "studio_simple.sdf" world by default which doesn't exist and would cause studio to fail to load. Change this to use the "empty.sdf" world which exists in the picknik_accessories repo