### PR TITLE
Add missing Lidar parameter

### DIFF
--- a/src/kinova_gen3_mujoco_config/description/picknik_kinova_gen3.xacro
+++ b/src/kinova_gen3_mujoco_config/description/picknik_kinova_gen3.xacro
@@ -681,6 +681,7 @@
         <param name="mujoco_model_package">kinova_gen3_mujoco_config</param>
         <param name="render_publish_rate">10</param>
         <param name="tf_publish_rate">60</param>
+        <param name="lidar_publish_rate">10</param>
       </hardware>
     </ros2_control>
 


### PR DESCRIPTION
Due to the LIDAR PR that went into the `ros2_mujoco` repo, a `lidar_publish_rate` `ros2_control` parameter is now required. This PR adds that PR to the Kinova URDF.