### PR TITLE
Add Get Imarker Pose from Mesh Visualization Objective

### DIFF
--- a/src/kinova_gen3_base_config/objectives/get_imarker_pose_from_mesh_visualization.xml
+++ b/src/kinova_gen3_base_config/objectives/get_imarker_pose_from_mesh_visualization.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<root BTCPP_format="4" main_tree_to_execute="Get IMarker Pose From Mesh Visualization">
+  <!--//////////-->
+  <BehaviorTree ID="Get IMarker Pose From Mesh Visualization" _description="Visualize a mesh in the UI and use an IMarker to get a grasp pose based on that mesh" _favorite="false">
+    <Control ID="Sequence" name="TopLevelSequence">
+      <Action ID="VisualizeMesh" marker_lifetime="0.0"/>
+      <Action ID="AddPoseStampedToVector" input="{mesh_pose}"/>
+      <Action ID="AdjustPoseWithIMarker" initial_poses="{pose_stamped_vector}" adjusted_poses="{adjusted_poses}" prompts="Adjust IMarker for Poses relative to the mesh"/>
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Get IMarker Pose From Mesh Visualization">
+      <output_port name="adjusted_poses" default="{adjusted_poses}"/>
+      <input_port name="mesh_path" default="{mesh_path}"/>
+      <input_port name="mesh_pose" default="{mesh_pose}"/>
+      <input_port name="_collapsed" default="false"/>
+    </SubTree>
+  </TreeNodesModel>
+</root>


### PR DESCRIPTION
Partially resolves https://github.com/PickNikRobotics/moveit_studio/issues/7603

# To test:
The `Get IMarker Pose From Mesh Visualization` Objective is intended to be used as a SubTree. Here is an example Objective that utilizes it:

```
<?xml version='1.0' encoding='UTF-8'?>
<root BTCPP_format="4" main_tree_to_execute="Test IMarkerPose With Viz Mesh">
  <!--//////////-->
  <BehaviorTree ID="Test IMarkerPose With Viz Mesh" _description="" _favorite="true">
    <Control ID="Sequence" name="TopLevelSequence">
      <Action ID="CreateStampedPose" orientation_xyzw="0.0;0.0;1.0;0.0" position_xyz="1.25;0.125;0.0" stamped_pose="{mesh_pose}"/>
      <SubTree ID="Get IMarker Pose From Mesh Visualization" _collapsed="false" adjusted_poses="{adjusted_poses}" mesh_path="package://picknik_accessories/descriptions/furniture/cabinet/cabinet.dae" mesh_pose="{mesh_pose}" target_poses="{adjusted_poses}"/>
      <Decorator ID="ForEachPoseStamped" vector_in="{adjusted_poses}" out="{target_pose}">
        <Control ID="Fallback" name="root">
          <Control ID="Sequence">
            <Action ID="InitializeMTCTask" task_id="move_to_pose" controller_names="/joint_trajectory_controller" task="{move_to_pose_task}"/>
            <Action ID="SetupMTCCurrentState" task="{move_to_pose_task}"/>
            <Action ID="SetupMTCMoveToPose" ik_frame="grasp_link" planning_group_name="manipulator" target_pose="{target_pose}" task="{move_to_pose_task}" planner_interface="moveit_default"/>
            <Action ID="PlanMTCTask" solution="{move_to_pose_solution}" task="{move_to_pose_task}"/>
            <SubTree ID="Wait for Trajectory Approval if User Available" solution="{move_to_pose_solution}"/>
            <Action ID="ExecuteMTCTask" solution="{move_to_pose_solution}"/>
            <Action ID="PublishEmpty" topic="/studio_ui/motion_ended" queue_size="1" use_best_effort="false"/>
          </Control>
          <Control ID="Sequence">
            <Action ID="PublishEmpty" topic="/studio_ui/motion_ended" queue_size="1" use_best_effort="false"/>
            <Action ID="AlwaysFailure"/>
          </Control>
        </Control>        
      </Decorator>
    </Control>
  </BehaviorTree>
</root>
```