### PR TITLE
Match casing of 'as' and 'FROM' in Dockerfile

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -16,7 +16,7 @@ ARG USER_GID=1000
 ##################################################
 # The image tag is specified in the argument itself.
 # hadolint ignore=DL3006
-FROM ${MOVEIT_STUDIO_BASE_IMAGE} as base
+FROM ${MOVEIT_STUDIO_BASE_IMAGE} AS base
 
 # Create a non-root user
 ARG USERNAME
@@ -80,7 +80,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 ###################################################################
 # Target for the developer build which does not compile any code. #
 ###################################################################
-FROM base as user-overlay-dev
+FROM base AS user-overlay-dev
 
 ARG USERNAME
 ARG USER_WS=/home/${USERNAME}/user_ws
@@ -102,7 +102,7 @@ CMD ["/usr/bin/bash"]
 #########################################
 # Target for compiled, deployable image #
 #########################################
-FROM base as user-overlay
+FROM base AS user-overlay
 
 ARG USERNAME
 ARG USER_WS=/home/${USERNAME}/user_ws


### PR DESCRIPTION
Gets rid of warning:
```
=> WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line xx)
```